### PR TITLE
V3 asg rolling update

### DIFF
--- a/etcd-aws.go
+++ b/etcd-aws.go
@@ -59,6 +59,7 @@ type etcdHealth struct {
 	Health string `json:"health"`
 }
 
+var awsSession *session.Session
 var localInstance *ec2.Instance
 var peerProtocol string
 var clientProtocol string
@@ -359,7 +360,7 @@ func main() {
 		}
 	}
 
-	awsSession := session.New()
+	awsSession = session.New()
 	if region := os.Getenv("AWS_REGION"); region != "" {
 		awsSession.Config.WithRegion(region)
 	}

--- a/etcd-aws.go
+++ b/etcd-aws.go
@@ -84,11 +84,18 @@ func getHttpClient() (*http.Client, error) {
 			RootCAs:      caCertPool,
 		}
 		tlsConfig.BuildNameToCertificate()
-		transport = &http.Transport{TLSClientConfig: tlsConfig}
+		transport = &http.Transport{
+			TLSClientConfig:     tlsConfig,
+			TLSHandshakeTimeout: 2 * time.Second,
+		}
 	} else {
 		transport = &http.Transport{}
 	}
-	client := &http.Client{Transport: transport}
+
+	transport.IdleConnTimeout = 10 * time.Second
+	transport.ResponseHeaderTimeout = 2 * time.Second
+	transport.ExpectContinueTimeout = 10 * time.Second
+	client := &http.Client{Transport: transport, Timeout: 20 * time.Second}
 	return client, nil
 }
 

--- a/etcd-aws.go
+++ b/etcd-aws.go
@@ -55,6 +55,10 @@ type etcdMember struct {
 	ClientURLs []string `json:"clientURLs,omitempty"`
 }
 
+type etcdHealth struct {
+	Health string `json:"health"`
+}
+
 var localInstance *ec2.Instance
 var peerProtocol string
 var clientProtocol string
@@ -140,8 +144,14 @@ func getApiResponseWithBody(privateIpAddress string, instanceId string, path str
 	var req *http.Request
 
 	if bodyType == "" {
-		req, _ = http.NewRequest(method, fmt.Sprintf("%s://%s:%s/v2/%s",
-			clientProtocol, privateIpAddress, *etcdClientPort, path), body)
+		// health is an unversioned endpoint
+		if path == "health" {
+			req, _ = http.NewRequest(method, fmt.Sprintf("%s://%s:%s/%s",
+				clientProtocol, privateIpAddress, *etcdClientPort, path), body)
+		} else {
+			req, _ = http.NewRequest(method, fmt.Sprintf("%s://%s:%s/v2/%s",
+				clientProtocol, privateIpAddress, *etcdClientPort, path), body)
+		}
 	}
 
 	client, err := getHttpClient()

--- a/etcd-aws.go
+++ b/etcd-aws.go
@@ -177,9 +177,23 @@ func getApiResponseWithBody(privateIpAddress string, instanceId string, path str
 	return resp, nil
 }
 
-func buildCluster(s *ec2cluster.Cluster) (initialClusterState string, initialCluster []string, err error) {
+const ec2StateRunning int64 = 16
 
+/*
+	Determines whether local instance should attempt to:
+	* Join an existing cluster via a healthy member
+		* Members must be part of an ASG
+		* All members must have the same leader
+	* Error if an existing cluster is unhealthy
+	* Bootstrap a new cluster with instances of the local instance's ASG
+**/
+func buildCluster(s *ec2cluster.Cluster) (initialClusterState string, initialCluster []string, err error) {
 	localInstance, err := s.Instance()
+	if err != nil {
+		return "", nil, err
+	}
+
+	asg, err := s.AutoscalingGroup()
 	if err != nil {
 		return "", nil, err
 	}
@@ -189,62 +203,148 @@ func buildCluster(s *ec2cluster.Cluster) (initialClusterState string, initialClu
 		return "", nil, fmt.Errorf("list members: %s", err)
 	}
 
-	initialClusterState = "new"
-	initialCluster = []string{}
+	asgMembers := []string{}
+	existingCluster := []string{}
+	clusterLeader := ""
+	membersHaveLeader := 0
+	var healthyMember *ec2.Instance
+
 	for _, instance := range clusterInstances {
 		if instance.PrivateIpAddress == nil {
 			continue
 		}
-		log.Printf("getting stats from %s (%s)", *instance.InstanceId, *instance.PrivateIpAddress)
 
-		// add this instance to the initialCluster expression
-		initialCluster = append(initialCluster, fmt.Sprintf("%s=%s://%s:%s",
-			*instance.InstanceId, peerProtocol, *instance.PrivateIpAddress, *etcdPeerPort))
-
-		// skip the local node, since we know it is not running yet
-		if *instance.InstanceId == *localInstance.InstanceId {
+		if *instance.State.Code > ec2StateRunning {
 			continue
 		}
+
+		if *instance.InstanceId == *localInstance.InstanceId {
+			local := fmt.Sprintf("%s=%s://%s:%s",
+				*instance.InstanceId, peerProtocol, *instance.PrivateIpAddress, *etcdPeerPort)
+			asgMembers = append(asgMembers, local)
+			existingCluster = append(existingCluster, local)
+			continue
+		}
+
+		instance_in_asg := false
+
+		for _, tag := range instance.Tags {
+			if *tag.Key == "aws:autoscaling:groupName" {
+				instance_in_asg = true
+
+				if *tag.Value == *asg.AutoScalingGroupName {
+					local := fmt.Sprintf("%s=%s://%s:%s",
+						*instance.InstanceId, peerProtocol, *instance.PrivateIpAddress, *etcdPeerPort)
+					asgMembers = append(asgMembers, local)
+				}
+				break
+			}
+		}
+
+		if !instance_in_asg {
+			continue
+		}
+
+		log.Printf("getting stats from %s (%s)", *instance.InstanceId, *instance.PrivateIpAddress)
 
 		// fetch the state of the node.
 		path := "stats/self"
 		resp, err := getApiResponse(*instance.PrivateIpAddress, *instance.InstanceId, path, http.MethodGet)
 		if err != nil {
-			log.Printf("%s: %s://%s:%s/v2/%s: %s", *instance.InstanceId, clientProtocol,
-				*instance.PrivateIpAddress, *etcdClientPort, path, err)
+			log.Printf("%s: %s: %s", *instance.InstanceId, path, err)
 			continue
 		}
 		nodeState := etcdState{}
 		if err := json.NewDecoder(resp.Body).Decode(&nodeState); err != nil {
-			log.Printf("%s: %s://%s:%s/v2/%s: %s", *instance.InstanceId, clientProtocol,
-				*instance.PrivateIpAddress, *etcdClientPort, path, err)
+			log.Printf("%s: %s: %s", *instance.InstanceId, resp.Request.URL, err)
 			continue
 		}
 
 		if nodeState.LeaderInfo.Leader == "" {
-			log.Printf("%s: %s://%s:%s/v2/%s: alive, no leader", *instance.InstanceId, clientProtocol,
-				*instance.PrivateIpAddress, *etcdClientPort, path)
+			log.Printf("%s: %s: alive, no leader", *instance.InstanceId, resp.Request.URL)
 			continue
 		}
 
-		log.Printf("%s: %s://%s:%s/v2/%s: has leader %s", *instance.InstanceId, clientProtocol,
-			*instance.PrivateIpAddress, *etcdClientPort, path, nodeState.LeaderInfo.Leader)
-		if initialClusterState != "existing" {
-			initialClusterState = "existing"
+		membersHaveLeader += 1
 
-			// inform the node we found about the new node we're about to add so that
-			// when etcd starts we can avoid etcd thinking the cluster is out of sync.
-			log.Printf("joining cluster via %s", *instance.InstanceId)
-			m := etcdMember{
-				Name: *localInstance.InstanceId,
-				PeerURLs: []string{fmt.Sprintf("%s://%s:%s",
-					peerProtocol, *localInstance.PrivateIpAddress, *etcdPeerPort)},
+		if clusterLeader == "" {
+			clusterLeader = nodeState.LeaderInfo.Leader
+		}
+
+		log.Printf("%s: %s: has leader %s", *instance.InstanceId,
+			resp.Request.URL, nodeState.LeaderInfo.Leader)
+
+		if nodeState.LeaderInfo.Leader != clusterLeader {
+			return "", nil, fmt.Errorf("unhealthy cluster: nodes reporting different leaders")
+		}
+
+		local := fmt.Sprintf("%s=%s://%s:%s",
+			*instance.InstanceId, peerProtocol, *instance.PrivateIpAddress, *etcdPeerPort)
+		existingCluster = append(existingCluster, local)
+
+		if healthyMember == nil {
+			resp, err := getApiResponse(*instance.PrivateIpAddress, *localInstance.InstanceId, "health", http.MethodGet)
+			if err != nil {
+				continue
 			}
-			body, _ := json.Marshal(m)
-			getApiResponseWithBody(*instance.PrivateIpAddress, *instance.InstanceId, "members", http.MethodPost, "application/json", bytes.NewReader(body))
+
+			health := etcdHealth{}
+			if err = json.NewDecoder(resp.Body).Decode(&health); err != nil {
+				continue
+			}
+
+			if health.Health == "true" {
+				resp, err = getApiResponse(*instance.PrivateIpAddress, *instance.InstanceId, "members", http.MethodGet)
+				if err != nil {
+					continue
+				}
+				defer resp.Body.Close()
+				members := etcdMembers{}
+				if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+					continue
+				}
+
+				alreadyMember := false
+				for _, member := range members.Members {
+					if member.Name == *localInstance.InstanceId {
+						alreadyMember = true
+						break
+					}
+				}
+				if !alreadyMember {
+					healthyMember = instance
+				}
+			}
 		}
 	}
-	return initialClusterState, initialCluster, nil
+
+	if membersHaveLeader == 0 || healthyMember == nil {
+		return "new", asgMembers, nil
+	}
+
+	// inform the node we found about the new node we're about to add so that
+	// when etcd starts we can avoid etcd thinking the cluster is out of sync.
+	log.Printf("joining cluster via %s", *healthyMember.InstanceId)
+	m := etcdMember{
+		Name: *localInstance.InstanceId,
+		PeerURLs: []string{fmt.Sprintf("%s://%s:%s",
+			peerProtocol, *localInstance.PrivateIpAddress, *etcdPeerPort)},
+	}
+	body, _ := json.Marshal(m)
+
+	resp, err := getApiResponseWithBody(*healthyMember.PrivateIpAddress, *healthyMember.InstanceId, "members", http.MethodPost, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", nil, fmt.Errorf("%s: joining cluster failed: %s", m.PeerURLs[0], err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ = ioutil.ReadAll(resp.Body)
+		return "", nil, fmt.Errorf("%s: received %d status: %s", m.PeerURLs[0], resp.StatusCode, string(body))
+	}
+
+	return "existing", existingCluster, nil
 }
 
 func main() {
@@ -384,6 +484,9 @@ func main() {
 	}
 
 	initialClusterState, initialCluster, err := buildCluster(s)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
 	log.Printf("initial cluster: %s %s", initialClusterState, initialCluster)
 
 	// start the backup and restore goroutine.

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -8,49 +8,120 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/crewjam/ec2cluster"
 )
 
-// handleLifecycleEvent is invoked whenever we get a lifecycle terminate message. It removes
-// terminated instances from the etcd cluster.
+// handleLifecycleEvent is invoked whenever we get a lifecycle
+// launching or terminating message. It notifies the ASG when launching
+// instances may be brought into service. And removes terminating instances
+// from the etcd cluster. Calls are retried as the cluster may be unable
+// to add or remove members if doing so would cause the cluster to become
+// unhealthy.
 func handleLifecycleEvent(m *ec2cluster.LifecycleMessage) (shouldContinue bool, err error) {
-	if m.LifecycleTransition != "autoscaling:EC2_INSTANCE_TERMINATING" {
+	switch m.LifecycleTransition {
+	default:
 		return true, nil
-	}
+	case "autoscaling:EC2_INSTANCE_LAUNCHING":
+		// TODO: move this to ec2cluster?
+		ec2Svc := ec2.New(awsSession)
+		ec2Resp, err := ec2Svc.DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(m.EC2InstanceID)},
+		})
 
-	// look for the instance in the cluster
-	resp, err := getApiResponse(*localInstance.PrivateIpAddress, *localInstance.InstanceId, "members", http.MethodGet)
-	if err != nil {
-		return false, err
-	}
-	members := etcdMembers{}
-	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-		return false, err
-	}
-	memberID := ""
-	for _, member := range members.Members {
-		if member.Name == m.EC2InstanceID {
-			memberID = member.ID
+		if err != nil {
+			return false, err
 		}
-	}
 
-	if memberID == "" {
-		log.WithField("InstanceID", m.EC2InstanceID).Warn("received termination event for non-member")
+		if len(ec2Resp.Reservations) != 1 || len(ec2Resp.Reservations[0].Instances) != 1 {
+			return false, fmt.Errorf("Cannot find instance %s", m.EC2InstanceID)
+		}
+
+		instance := ec2Resp.Reservations[0].Instances[0]
+		var health etcdHealth
+		for i := 0; i < 10; i++ {
+			resp, err := getApiResponse(*instance.PrivateIpAddress, *localInstance.InstanceId, "health", http.MethodGet)
+			if err != nil {
+				if i == 10 {
+					log.Printf("health query failed; erroring")
+					return false, err
+				}
+
+				log.Printf("health query failed; sleeping")
+				time.Sleep(1 + time.Duration(i)*3*time.Second)
+				continue
+			}
+
+			if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+				log.Printf("json decoding error")
+				return false, err
+			}
+
+			if health.Health == "true" {
+				break
+			}
+
+			if i == 10 {
+				log.Printf("new node unable to become healthy: %s", m.EC2InstanceID)
+				return false, fmt.Errorf("new node unable to become healthy: %s", m.EC2InstanceID)
+			}
+		}
+
 		return true, nil
+	case "autoscaling:EC2_INSTANCE_TERMINATING":
+		// look for the instance in the cluster
+		resp, err := getApiResponse(*localInstance.PrivateIpAddress, *localInstance.InstanceId, "members", http.MethodGet)
+		if err != nil {
+			return false, err
+		}
+		members := etcdMembers{}
+		if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+			return false, err
+		}
+		memberID := ""
+		for _, member := range members.Members {
+			if member.Name == m.EC2InstanceID {
+				memberID = member.ID
+			}
+		}
+
+		if memberID == "" {
+			log.WithField("InstanceID", m.EC2InstanceID).Warn("received termination event for non-member")
+			return true, nil
+		}
+
+		log.WithFields(log.Fields{
+			"InstanceID": m.EC2InstanceID,
+			"MemberID":   memberID}).Info("removing from cluster")
+
+		for i := 0; i < 10; i++ {
+			resp, err = getApiResponse(*localInstance.PrivateIpAddress, *localInstance.InstanceId, fmt.Sprintf("members/%s", memberID), http.MethodDelete)
+			if err != nil {
+				if i == 10 {
+					log.Printf("delete member failed; erroring")
+					return false, err
+				}
+
+				log.Printf("delete member failed; sleeping")
+				time.Sleep(1 + time.Duration(i)*3*time.Second)
+				continue
+			}
+
+			if resp.StatusCode == 200 {
+				break
+			}
+
+			if i == 10 {
+				log.Printf("node unable to be removed from cluster: %s", m.EC2InstanceID)
+				return false, fmt.Errorf("node unable to be removed from cluster: %s", m.EC2InstanceID)
+			}
+		}
+
+		return false, nil
 	}
-
-	log.WithFields(log.Fields{
-		"InstanceID": m.EC2InstanceID,
-		"MemberID":   memberID}).Info("removing from cluster")
-
-	resp, err = getApiResponse(*localInstance.PrivateIpAddress, *localInstance.InstanceId, fmt.Sprintf("members/%s", memberID), http.MethodDelete)
-	if err != nil {
-		return false, err
-	}
-
-	return false, nil
 }
 
 func watchLifecycleEvents(s *ec2cluster.Cluster, queueName string) {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -110,7 +110,7 @@ func handleLifecycleEvent(m *ec2cluster.LifecycleMessage) (shouldContinue bool, 
 				continue
 			}
 
-			if resp.StatusCode == 200 {
+			if resp.StatusCode == http.StatusOK {
 				break
 			}
 


### PR DESCRIPTION
I'm using Terraform to manage the ASG for an etcd cluster. Terraform provides an option to create_before_destroy on resources, in this case ASGs. This allows me to make changes to a launch configuration, which will result in a new ASG being created before the old ASG is destroyed. I've extended etcd-aws to orchestrate the process of new instances joining the cluster and becoming healthy before the old instances are destroyed.

buildCluster has been improved to discover instances across ASGs using the same tag (using the value passed to -tag, ensure that any existing cluster members report the same leader, and if needed, attempt to join via a healthy member of the cluster. Bootstrapping a new cluster will be done when no existing cluster is discovered, and only instances within a single ASG will be used for bootstrapping. If an existing cluster is discovered, but found to be unhealthy (members reporting different leaders, no healthy members found), etcd-aws will error and exit as doing otherwise could put the existing cluster at further risk for data loss or corruption.

A launching lifecycle hook has been added to ensure that new instances are joined to the cluster and are reporting as healthy before being brought In-Service.

The terminating lifecycle hook has been made more robust by ensuring the member that is terminating is removed from the cluster, and this attempt will be retried in the event it fails in the event the cluster is not ready to remove a member.

Thanks to @crewjam and the Opsline folks for making this possible!